### PR TITLE
Change the Content-Type in the response header

### DIFF
--- a/src/flub-error-handler.ts
+++ b/src/flub-error-handler.ts
@@ -17,7 +17,8 @@ export class FlubErrorHandler implements ExceptionFilter {
       .then(data => {
         const ctx = host.switchToHttp();
         const response = ctx.getResponse();
-
+        
+        response.header('Content-Type', 'text/html; charset=UTF-8');
         response.status(500).send(data);
       })
       .catch(e => {


### PR DESCRIPTION
Hey I use Fastify and in my Scenario the Content-Type was plain text, with this small change we can make sure that the content type is set correctly.
